### PR TITLE
Add dedicated skills page

### DIFF
--- a/data.js
+++ b/data.js
@@ -17,7 +17,7 @@ const portfolioData = {
     navigation: [
         { href: "#about", text: "About" },
         { href: "#timeline", text: "Experience" },
-        { href: "#skills", text: "Skills" },
+        { href: "skills.html", text: "Skills" },
         { href: "projects.html", text: "Projects" }
     ],
 

--- a/index.html
+++ b/index.html
@@ -127,14 +127,6 @@
     </section>
 
 
-    <section class="skills">
-        <div class="container">
-            <h2>Technical Skills</h2>
-            <div class="skills-grid">
-                <!-- Skills will be populated by JavaScript -->
-            </div>
-        </div>
-    </section>
 
 
 

--- a/projects-app.js
+++ b/projects-app.js
@@ -44,7 +44,7 @@ function populateHeader() {
             { href: "index.html", text: "Home" },
             { href: "index.html#about", text: "About" },
             { href: "index.html#timeline", text: "Experience" },
-            { href: "index.html#skills", text: "Skills" },
+            { href: "skills.html", text: "Skills" },
             { href: "projects.html", text: "Projects", active: true }
         ];
         

--- a/skills-app.js
+++ b/skills-app.js
@@ -1,0 +1,97 @@
+// skills-app.js - Skills Page Dynamic Content
+
+document.addEventListener('DOMContentLoaded', function() {
+    initializeSkillsPage();
+});
+
+function initializeSkillsPage() {
+    if (typeof portfolioData === 'undefined') {
+        console.error('Portfolio data not found. Please ensure data.js is loaded.');
+        return;
+    }
+
+    populateHeader();
+    populateSkills();
+    populateFooter();
+
+    document.title = `Skills - ${portfolioData.personal.name}`;
+    document.getElementById('current-year').textContent = new Date().getFullYear();
+}
+
+// Populate Header with active Skills link
+function populateHeader() {
+    const brandName = document.querySelector('.brand-name');
+    if (brandName) {
+        brandName.textContent = portfolioData.personal.name;
+    }
+
+    const navLinks = document.querySelector('.nav-links');
+    if (navLinks) {
+        const skillsNav = [
+            { href: 'index.html', text: 'Home' },
+            { href: 'index.html#about', text: 'About' },
+            { href: 'index.html#timeline', text: 'Experience' },
+            { href: 'skills.html', text: 'Skills', active: true },
+            { href: 'projects.html', text: 'Projects' }
+        ];
+
+        skillsNav.forEach(link => {
+            const navLink = document.createElement('a');
+            navLink.href = link.href;
+            navLink.className = link.active ? 'nav-link active' : 'nav-link';
+            navLink.textContent = link.text;
+            navLinks.appendChild(navLink);
+        });
+    }
+}
+
+// Populate Skills Grid
+function populateSkills() {
+    const skillsGrid = document.querySelector('.skills-grid');
+    if (!skillsGrid) return;
+
+    portfolioData.skills.forEach(category => {
+        const skillCategory = document.createElement('div');
+        skillCategory.className = 'skill-category';
+        skillCategory.setAttribute('data-aos', 'fade-up');
+
+        const title = document.createElement('h3');
+        title.textContent = category.category;
+        skillCategory.appendChild(title);
+
+        category.items.forEach(skill => {
+            const skillDiv = document.createElement('div');
+            skillDiv.className = 'skill';
+            skillDiv.setAttribute('data-level', skill.level);
+            skillDiv.textContent = skill.name;
+            skillCategory.appendChild(skillDiv);
+        });
+
+        skillsGrid.appendChild(skillCategory);
+    });
+}
+
+// Populate Footer (same as projects page)
+function populateFooter() {
+    const socialLinks = document.querySelector('footer .social-links');
+    if (socialLinks) {
+        portfolioData.social.forEach(social => {
+            const link = document.createElement('a');
+            link.href = social.url;
+            link.target = '_blank';
+            link.rel = 'noopener noreferrer';
+            link.setAttribute('aria-label', social.label);
+
+            const icon = document.createElement('i');
+            icon.className = social.icon;
+            link.appendChild(icon);
+
+            socialLinks.appendChild(link);
+        });
+    }
+
+    const footerName = document.getElementById('footer-name');
+    if (footerName) {
+        footerName.textContent = portfolioData.personal.name;
+    }
+}

--- a/skills.html
+++ b/skills.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Skills - Portfolio</title>
+    <link rel="stylesheet" href="styles.css">
+    <link rel="stylesheet" href="styles-dynamic.css">
+    <link rel="stylesheet" href="projects-page.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" integrity="sha512-Fo3rlrZj/k7ujTnHg4CGR2D7kSs0v4LLanw2qksYuRlEzO+tcaEPQogQ0KaoGN26/zrn20ImR1DfuLWnOo7aBA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/aos/2.3.4/aos.css" integrity="sha512-1cK78a1o+ht2JcaW6g8OXYwqpev9+6GqOkz9xmBN9iUUhIndKtxwILZFYJ5PGxfpd6FG8ISRcMbHHKF0e5pjek==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+</head>
+<body>
+    <!-- Code Background Effect -->
+    <canvas id="codeCanvas"></canvas>
+    <div class="mouse-glow"></div>
+
+    <header class="header">
+        <div class="container">
+            <div class="header-content">
+                <div class="brand">
+                    <a href="index.html" class="logo">VR</a>
+                    <span class="brand-name"></span>
+                </div>
+                <nav class="nav-links">
+                    <!-- Navigation links will be populated by JavaScript -->
+                </nav>
+                <button class="theme-toggle" id="themeToggle" aria-label="Toggle theme">
+                    <i class="fas fa-moon"></i>
+                </button>
+                <button class="mobile-menu-btn" id="mobileMenuBtn" aria-label="Toggle menu">
+                    <i class="fas fa-bars"></i>
+                </button>
+            </div>
+        </div>
+    </header>
+
+    <main class="projects-main">
+        <div class="container">
+            <div class="projects-hero">
+                <h1 class="projects-title">My Skills</h1>
+                <p class="projects-subtitle">Technologies & Expertise</p>
+            </div>
+
+            <div class="skills-grid">
+                <!-- Skills will be populated by JavaScript -->
+            </div>
+        </div>
+    </main>
+
+    <footer>
+        <div class="container">
+            <div class="social-links">
+                <!-- Social links will be populated by JavaScript -->
+            </div>
+            <p>&copy; <span id="current-year"></span> <span id="footer-name"></span>. All rights reserved.</p>
+        </div>
+    </footer>
+
+    <!-- JavaScript -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/aos/2.3.4/aos.js"></script>
+
+    <!-- Portfolio Data Configuration -->
+    <script src="data.js"></script>
+
+    <!-- Skills Page Scripts -->
+    <script src="skills-app.js"></script>
+    <script src="code-background.js"></script>
+
+    <!-- Shared Scripts -->
+    <script src="script.js" defer></script>
+
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            if (typeof AOS !== 'undefined') {
+                setTimeout(() => {
+                    AOS.init({
+                        duration: 800,
+                        easing: 'ease-in-out',
+                        once: true
+                    });
+                }, 100);
+            }
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create a standalone Skills page with the same theme as Projects
- dynamically populate skills using new `skills-app.js`
- update navigation links for Skills page
- remove skills section from home page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6858066677a48328adca6954df2e2cbc